### PR TITLE
github actions 활성화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,9 +41,8 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_PRIVATE_KEY }}
-          script_stop: true
+          script_stop: false
           script: |
             cd /home/ubuntu/futsal-finder
             pkill -f futsal-finder.jar || true
             nohup java -jar futsal-finder.jar > app.log 2>&1 &
-            wait || true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,3 +46,4 @@ jobs:
             cd /home/ubuntu/futsal-finder
             pkill -f futsal-finder.jar || true
             nohup java -jar futsal-finder.jar > app.log 2>&1 &
+        continue-on-error: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,49 @@
+name: Deploy To EC2
+
+on:
+  push:
+    branches: [ "main", "ci/cd" ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Github Repository 파일 불러오기
+        uses: actions/checkout@v4
+
+      - name: JDK 17버전 설치
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: gradlew 파일 실행 권한 추가
+        run: chmod +x ./gradlew
+
+      - name: 테스트 및 빌드하기
+        run: ./gradlew clean build -x test
+
+      - name: 빌드된 파일 이름 변경하기
+        run: mv ./build/libs/*SNAPSHOT.jar ./futsal-finder.jar
+
+      - name: SCP로 EC2에 빌드된 파일 전송하기
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          source: futsal-finder.jar
+          target: /home/ubuntu/futsal-finder
+
+      - name: SSH로 EC2에 접속하여 배포 스크립트 실행
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          script_stop: true
+          script: |
+            cd /home/ubuntu/futsal-finder
+            pkill -f futsal-finder.jar || true
+            wait || true
+            nohup java -jar futsal-finder.jar > app.log 2>&1 &

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,5 @@ jobs:
           script_stop: false
           script: |
             cd /home/ubuntu/futsal-finder
-            pkill -f futsal-finder.jar || true
-            nohup java -jar futsal-finder.jar > app.log 2>&1 &
+            bash deploy.sh
         continue-on-error: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,5 +45,5 @@ jobs:
           script: |
             cd /home/ubuntu/futsal-finder
             pkill -f futsal-finder.jar || true
-            wait || true
             nohup java -jar futsal-finder.jar > app.log 2>&1 &
+            wait || true

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
-.github/workflows/
 
 ### STS ###
 .apt_generated


### PR DESCRIPTION
SSH 배포 스크립트 실행 시 발생하는 143(SIGTERM) 문제 해결

- GitHub Actions의 "SSH로 EC2에 접속하여 배포 스크립트 실행" 스텝에서 143(SIGTERM)으로 인한 실패를 방지하기 위해 continue-on-error: true 설정 적용